### PR TITLE
(fix): unscoped miner_res variable

### DIFF
--- a/src/mining.js
+++ b/src/mining.js
@@ -251,10 +251,9 @@ const miningHandler = async (conn, data, mainListener, usingAVR) => {
 
         conn.lastminshares++;
 
+        let miner_res = parseInt(answer[0]);
         if (usingAVR) {
             miner_res = parseInt(answer[0], 2);
-        } else {
-            miner_res = parseInt(answer[0]);
         }
 
         /* try {


### PR DESCRIPTION
It seems that the `miner_res` variable is not scoped via `let` or `const` keyword. It is simply defined dynamically. This way the `miner_res` variable is defined as a global variable. As a result, it could happend when 2 devices are reporting at the same time, the `miner_res` variable is overridden by the next request and let the first request fail because it has simply the wrong (result of the last request) `miner_res` variable.

By scoping this variable via `let` it is scoped to the function and therefor it cannot be override by the other requests.

I notice this while I was testing my updated ESP32 code agains this repo (so I can test it locally), where the hashrate is fixed by using the software hashing instead of hardware (see https://github.com/revoxhere/duino-coin/issues/1682#issuecomment-1811139791). I enabled 5 esp32 with the updated code, so 10 clients were connected.

By putting a `console.log` here https://github.com/revoxhere/duino-coin-pools/blob/main/src/mining.js#L362

```
console.log(
    "BAD,Incorrect result",
    `miner_res=${miner_res}`,
    `random=${random}`,
    answer,
);
```

I saw the following result where `100658` is the result of the previous request. However, the data that has been received is correctly. 

```
duino_coin_server    | BAD,Incorrect result miner_res=100658 random=27360 [
duino_coin_server    |   '27360', <------ This has been sent
duino_coin_server    |   '20168.13',
duino_coin_server    |   'PowerDuino I2C ESP32 Miner 1.0',
duino_coin__server    |   'ESP-REINOS-RIG [3]',
duino_coin_server    |   'DUCOIDB8FCF1549434'
duino_coin_server    | ]
```

NOTE: it seems that there are more variables suffering from this issue, but not sure if they are affected. Have look at `expectedSharetime`,  `reportedHashrate`,  `hashrate_calc`, `hashrateIsEstimated`, `hashrate`, `reward_div`, `maxHashrate`, `minHashrate`, `blockProbability`, `reward` and `kolka_drop`. All of those variables are defined dynamically, so they are treaded as global variable, in other words, an other process can override them and affect the result of an other.